### PR TITLE
Use AbuseFilterShouldFilterAction hook for Flow actions

### DIFF
--- a/.github/workflows/dependencies
+++ b/.github/workflows/dependencies
@@ -1,1 +1,2 @@
+AbuseFilter
 Flow

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -5,6 +5,7 @@ $cfg = require __DIR__ . '/../vendor/mediawiki/mediawiki-phan-config/src/config.
 $cfg['directory_list'] = array_merge(
 	$cfg['directory_list'],
 	[
+		'../../extensions/AbuseFilter',
 		'../../extensions/Flow',
 
 	]
@@ -13,6 +14,7 @@ $cfg['directory_list'] = array_merge(
 $cfg['exclude_analysis_directory_list'] = array_merge(
 	$cfg['exclude_analysis_directory_list'],
 	[
+		'../../extensions/AbuseFilter',
 		'../../extensions/Flow',
 	]
 );

--- a/extension.json
+++ b/extension.json
@@ -15,6 +15,7 @@
     "DiscordNotifications": ["i18n"]
   },
   "Hooks": {
+    "AbuseFilterShouldFilterAction": "MediaWiki\\Extension\\DiscordNotifications\\Hooks::onAbuseFilterShouldFilterAction",
     "AfterImportPage": "main",
     "APIFlowAfterExecute": "MediaWiki\\Extension\\DiscordNotifications\\Hooks::onAPIFlowAfterExecute",
     "ArticleDeleteComplete": "main",

--- a/includes/Core.php
+++ b/includes/Core.php
@@ -208,11 +208,14 @@ class Core {
 	}
 
 	/**
-	 * @param string $uuid
+	 * @param string|UUID $uuid
 	 * @return string
 	 */
-	public static function flowUUIDToTitleText( string $uuid ) {
-		$uuid = UUID::create( $uuid );
+	public static function flowUUIDToTitleText( $uuid ) {
+		if ( is_string( $uuid ) ) {
+			$uuid = strtolower( $uuid );
+			$uuid = UUID::create( $uuid );
+		}
 		$collection = \Flow\Collection\PostCollection::newFromId( $uuid );
 		$revision = $collection->getLastRevision();
 		return $revision->getContent( 'topic-title-plaintext' );

--- a/includes/Core.php
+++ b/includes/Core.php
@@ -209,12 +209,15 @@ class Core {
 
 	/**
 	 * @param string|UUID $uuid
-	 * @return string
+	 * @return string Text of the title for given UUID. If not found, empty string will be returned.
 	 */
 	public static function flowUUIDToTitleText( $uuid ) {
 		if ( is_string( $uuid ) ) {
 			$uuid = strtolower( $uuid );
 			$uuid = UUID::create( $uuid );
+		}
+		if ( !( $uuid instanceof UUID ) ) {
+			return '';
 		}
 		$collection = \Flow\Collection\PostCollection::newFromId( $uuid );
 		$revision = $collection->getLastRevision();

--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -2,6 +2,8 @@
 
 namespace MediaWiki\Extension\DiscordNotifications;
 
+use AbuseFilterVariableHolder;
+use AFComputedVariable;
 use APIBase;
 use Config;
 use Exception;
@@ -9,6 +11,7 @@ use ExtensionRegistry;
 use MediaWiki\MediaWikiServices;
 use SpecialPage;
 use Title;
+use User;
 
 class Hooks implements
 	\MediaWiki\Auth\Hook\LocalUserCreatedHook,
@@ -338,6 +341,14 @@ class Hooks implements
 			return;
 		}
 
+		# self::APIFlowAfterExecute() is used instead of this if available.
+		if ( ExtensionRegistry::getInstance()->isLoaded( 'Abuse Filter' )
+			&& in_array( $action, [ 'new-topic', 'edit-header', 'edit-post', 'edit-title', 'edit-topic-summary',
+				'reply' ] )
+		) {
+			return;
+		}
+
 		global $wgUser;
 		switch ( $action ) {
 			case 'edit-header':
@@ -421,6 +432,107 @@ class Hooks implements
 		}
 		$core = new Core();
 		$core->pushDiscordNotify( $message, $wgUser, 'flow' );
+	}
+
+	/**
+	 * self::APIFlowAfterExecute() is not triggered if the browser of the user does not support JavaScript.
+	 * To avoid that cases, we use this AbuseFilter hook if the extension is loaded.
+	 * @param AbuseFilterVariableHolder $vars
+	 * @param Title $title Title object target of the action
+	 * @param User $user User object performer of the action
+	 * @param array &$skipReasons Array of reasons why the action should be skipped
+	 * @return bool|void True or no return value to continue or false to abort
+	 */
+	public static function onAbuseFilterShouldFilterAction(
+		AbuseFilterVariableHolder $vars,
+		Title $title,
+		User $user,
+		array &$skipReasons
+	) {
+		global $wgDiscordNotificationsActions;
+
+		if ( !$wgDiscordNotificationsActions['flow'] || !ExtensionRegistry::getInstance()->isLoaded( 'Flow' ) ) {
+			return;
+		}
+
+		if ( Core::titleIsExcluded( $title ) ) {
+			return;
+		}
+
+		# It is tricky but possible to fetch the topic if the below condition matches.
+		# This must be done before the any call of $vars->getVar().
+		$newWikitext = $vars->mVars['new_wikitext'];
+		if ( $vars->mVars['action'] == 'new-post' && $newWikitext instanceof AFComputedVariable ) {
+			$rev = $newWikitext->mParameters['revision'];
+			$topicTitle = Title::newFromText( $rev->getPostId()->getAlphadecimal(), NS_TOPIC );
+		}
+
+		$userLink = LinkRenderer::getDiscordUserText( $user );
+		$action = $vars->getVar( 'action' )->data;
+		$pageTitleText = $vars->getVar( 'page_title' )->data;
+		$boardPrefixedTitleText = $vars->getVar( 'board_prefixedtitle' )->data;
+		$pagePrefixedTitleText = $vars->getVar( 'page_prefixedtitle' )->data;
+		$boardTitle = Title::newFromText( $boardPrefixedTitleText );
+		$pageTitle = Title::newFromText( $pagePrefixedTitleText );
+		$oldWikitext = $vars->getVar( 'old_wikitext' )->data;
+		$newWikitext = $vars->getVar( 'new_wikitext' )->data;
+
+		// Skip notifications if the reply is the first, in fact non a "re"-ply.
+		// The first reply is a content of the topic.
+		if ( $action == 'reply' && $boardTitle == $pageTitle ) {
+			return;
+		}
+
+		$core = new Core();
+		switch ( $action ) {
+			case 'new-post':
+				$topic = $newWikitext;
+				if ( $topicTitle ) {
+					$topic = LinkRenderer::makeLink( $topicTitle->getFullUrl(), $newWikitext );
+				}
+				$msg = Core::msg( 'discordnotifications-flow-new-topic',
+					$userLink,
+					$topic,
+					LinkRenderer::makeLink( $boardTitle->getFullUrl(), $boardPrefixedTitleText )
+				);
+				break;
+			case 'edit-post':
+				$msg = Core::msg( 'discordnotifications-flow-edit-post',
+					$userLink,
+					LinkRenderer::makeLink( $pageTitle->getFullUrl(),
+						Core::flowUUIDToTitleText( $pageTitleText ) )
+					# TODO use LinkRenderer::makeLink( $boardTitle->getFullUrl(), $boardPrefixedTitleText )
+				);
+				break;
+			case 'reply':
+				$msg = Core::msg( 'discordnotifications-flow-reply',
+					$userLink,
+					LinkRenderer::makeLink( $pageTitle->getFullUrl(),
+						Core::flowUUIDToTitleText( $pageTitleText ) )
+					# TODO use LinkRenderer::makeLink( $boardTitle->getFullUrl(), $boardPrefixedTitleText )
+				);
+				break;
+			case 'edit-title':
+				$msg = Core::msg( 'discordnotifications-flow-edit-title',
+					$userLink,
+					# TODO use $oldWikitext
+					LinkRenderer::makeLink( $boardTitle->getFullUrl(), $boardPrefixedTitleText ),
+					LinkRenderer::makeLink( $pageTitle->getFullUrl(), $newWikitext )
+				);
+				break;
+			case 'create-topic-summary':
+			case 'edit-topic-summary':
+				$msg = Core::msg( 'discordnotifications-flow-edit-header',
+					$userLink,
+					LinkRenderer::makeLink( $pageTitle->getFullUrl(),
+						Core::flowUUIDToTitleText( $pageTitleText ) )
+					# TODO use LinkRenderer::makeLink( $boardTitle->getFullUrl(), $boardPrefixedTitleText )
+				);
+				break;
+			default:
+				return;
+		}
+		$core->pushDiscordNotify( $msg, $user, 'flow' );
 	}
 
 	/**


### PR DESCRIPTION
Flow actions sent from JavaScript were ignored by this extension since the introduction.
This reduces the gap by using AbuseFilterShouldFilterAction hook if it is available.

Bug: https://github.com/femiwiki/femiwiki/issues/234